### PR TITLE
Fix Sphinx warning in OperatorConfig

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/entities/engine/operator_config.py
+++ b/presidio-anonymizer/presidio_anonymizer/entities/engine/operator_config.py
@@ -35,7 +35,7 @@ class OperatorConfig:
             "masking_char": "*",
             "chars_to_mask": 4,
             "from_end": true
-        }
+            }
         :return: OperatorConfig
         """
         operator_name = params.get("type")


### PR DESCRIPTION
## Description

In `OperatorConfig` method `from_json` the docstring had wrong indentation for a closing brace. This commit fixes this.

I'm sorry to bother you with this tiny minor fix. Since presidio itself doesn't generate docs for `OperatorConfig` - it's not affected. The change is only useful when somebody else builds on top of persidio and references the `OperatorConfig`

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
